### PR TITLE
Enable Dependabot Grouped Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    # Create a group of dependencies to be updated together in one pull request
+    groups:
+       # Specify a name for the group, which will be used in pull request titles
+       # and branch names
+       all-actions:
+          patterns:
+            - "*"       # A wildcard that matches all dependencies in the package
+                        # ecosystem. Note: using "*" may open a large pull request          


### PR DESCRIPTION
Enables [grouped dependabot updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)