### PR TITLE
CI - default to no permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ name: CI
 on:
   push
 
+#TODO What permission is need here to attach artifact to workflow run: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defining-access-for-the-github_token-scopes
+permissions: {}
+
 jobs:
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-          checks:write
+      checks: write
     steps:
 
       - name: checkout
@@ -56,7 +56,7 @@ jobs:
   build-on-win:
     runs-on: windows-latest
     permissions:
-      checks:write
+      checks: write
     continue-on-error: true
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+          checks:write
     steps:
 
       - name: checkout
@@ -53,6 +55,8 @@ jobs:
   ## For testing out tests on Windows
   build-on-win:
     runs-on: windows-latest
+    permissions:
+      checks:write
     continue-on-error: true
     steps:
 


### PR DESCRIPTION
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR7-R15): Added `checks: write` permissions to the `build` job that runs on `ubuntu-latest`.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR58-R59): Added `checks: write` permissions to the `build-on-win` job that runs on `windows-latest`. 

These changes ensure that the jobs in the workflow have the necessary permissions to perform their tasks after defaulting to `permissions: {}`