### PR TITLE
pin zyborg/pester-tests-report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
 
       - name: checkout
         uses: actions/checkout@v4
-      
+
       - name: pester tests
-        uses: zyborg/pester-tests-report@v1.5.0
+        uses: zyborg/pester-tests-report@bb711b31e93f78f7423086d57f81928325829765 # v1.5.0
         with:
           include_paths: ./tests/GitHubActions_tests.ps1
           exclude_tags: SkipCI
@@ -62,9 +62,9 @@ jobs:
 
       - name: checkout
         uses: actions/checkout@v4
-      
+
       - name: pester tests
-        uses: zyborg/pester-tests-report@v1.5.0
+        uses: zyborg/pester-tests-report@bb711b31e93f78f7423086d57f81928325829765 # v1.5.0
         with:
           include_paths: ./tests/GitHubActions_tests.ps1
           exclude_tags: SkipCI


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/ci.yml` file. The changes update the version of `zyborg/pester-tests-report` used in the `pester tests` job from `v1.5.0` to a specific commit hash `bb711b31e93f78f7423086d57f81928325829765`.