### PR TITLE
ci: add code coverage upload via upload-code-coverage-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,3 +142,33 @@ jobs:
         with:
           name: pester-results-windows
           path: TestResults/
+
+  # Separate job with minimal permissions for the coverage upload.
+  # Skipped for fork PRs (artifact won't have been uploaded).
+  upload-coverage:
+    needs: pester-ubuntu
+    if: ${{ !cancelled() && needs.pester-ubuntu.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # TODO: Reduce to `code-quality: write` once that permission scope ships.
+      security-events: write
+    steps:
+      # On PRs, check out the head commit (not the merge commit) so coverage
+      # data matches the commit SHA we report to the upload endpoint.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pester-results-ubuntu
+          path: TestResults/
+
+      - name: Upload code coverage
+        uses: code-quality-org/upload-code-coverage-action@main
+        with:
+          file: TestResults/coverage.cobertura.xml
+          language: PowerShell
+          label: code-coverage/pester

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,8 @@ jobs:
           path: TestResults/
 
   # Separate job with minimal permissions for the coverage upload.
-  # Skipped for fork PRs (artifact won't have been uploaded).
+  # Skipped for fork PRs because the coverage upload requires token
+  # permissions that are not available to workflows triggered from forks.
   upload-coverage:
     needs: pester-ubuntu
     if: ${{ !cancelled() && needs.pester-ubuntu.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # TODO: Reduce to `code-quality: write` once that permission scope ships.
-      security-events: write
+      code-quality: write
     steps:
       # On PRs, check out the head commit (not the merge commit) so coverage
       # data matches the commit SHA we report to the upload endpoint.
@@ -167,7 +166,7 @@ jobs:
           path: TestResults/
 
       - name: Upload code coverage
-        uses: code-quality-org/upload-code-coverage-action@main
+        uses: actions/upload-code-coverage@v1
         with:
           file: TestResults/coverage.cobertura.xml
           language: PowerShell


### PR DESCRIPTION
## Summary

Adds an `upload-coverage` job to the CI workflow that uploads the Pester Cobertura coverage report to GitHub's code coverage API using [`code-quality-org/upload-code-coverage-action`](https://github.com/code-quality-org/upload-code-coverage-action).

## Changes

- New `upload-coverage` job in `.github/workflows/ci.yml` that:
  - Depends on the `pester-ubuntu` job (only runs after tests pass)
  - Downloads the existing `pester-results-ubuntu` artifact
  - Uploads `TestResults/coverage.cobertura.xml` with `language: PowerShell` and `label: code-coverage/pester`
  - Uses minimal permissions (`contents: read`, `security-events: write`)
  - Skips fork PRs (token won't have write access)
  - Checks out the PR head commit (not the merge commit) so the SHA matches