### PR TITLE
Support GitHub Enterprise Cloud with data residency (ghe.com)

### DIFF
--- a/ActionHelpers.psm1
+++ b/ActionHelpers.psm1
@@ -106,8 +106,11 @@ function Get-PullRequestHtmlUrl {
     }
 
     try {
+        # Pass the absolute URI through to Invoke-GHRestMethod so the request goes to the host
+        # provided by the API (api.github.com, api.<tenant>.ghe.com, etc.) rather than relying on
+        # PowerShellForGitHub's ApiHostName configuration, which only supports github.com and GHES.
         $uri = [uri]$apiUrl
-        $response = Invoke-GHRestMethod -Method GET -Uri $uri.AbsolutePath
+        $response = Invoke-GHRestMethod -Method GET -Uri $uri.AbsoluteUri
         return $response.html_url
     }
     catch {
@@ -228,6 +231,10 @@ The repository name.
 .PARAMETER pullNumber
 The pull request number.
 
+.PARAMETER apiBaseUrl
+The GitHub API base URL (e.g., https://api.github.com or https://api.<tenant>.ghe.com).
+Defaults to https://api.github.com for backwards compatibility.
+
 .EXAMPLE
 Get-PullRequestComment -owner 'owner' -repo 'repo' -pullNumber 42
 Returns an array of comment objects.
@@ -236,13 +243,15 @@ function Get-PullRequestComment {
     param(
         [string]$owner,
         [string]$repo,
-        [int]$pullNumber
+        [int]$pullNumber,
+        [string]$apiBaseUrl = 'https://api.github.com'
     )
 
     $allComments = @()
     $perPage = 100
     $page = 1
-    $commentUrl = "/repos/$owner/$repo/issues/$pullNumber/comments?per_page=$perPage&page=$page"
+    $baseUrl = $apiBaseUrl.TrimEnd('/')
+    $commentUrl = "$baseUrl/repos/$owner/$repo/issues/$pullNumber/comments?per_page=$perPage&page=$page"
 
     try {
         while ($true) {
@@ -253,7 +262,7 @@ function Get-PullRequestComment {
                 break
             }
             $page++
-            $commentUrl = "/repos/$owner/$repo/issues/$pullNumber/comments?per_page=$perPage&page=$page"
+            $commentUrl = "$baseUrl/repos/$owner/$repo/issues/$pullNumber/comments?per_page=$perPage&page=$page"
         }
         return $allComments
     }
@@ -337,6 +346,10 @@ The repository name.
 .PARAMETER alertNumber
 The secret scanning alert number.
 
+.PARAMETER apiBaseUrl
+The GitHub API base URL (e.g., https://api.github.com or https://api.<tenant>.ghe.com).
+Defaults to https://api.github.com for backwards compatibility.
+
 .EXAMPLE
 Get-DismissalRequestForAlert -owner 'owner' -repo 'repo' -alertNumber 42
 Returns the dismissal request object or null.
@@ -345,7 +358,8 @@ function Get-DismissalRequestForAlert {
     param(
         [string]$owner,
         [string]$repo,
-        [int]$alertNumber
+        [int]$alertNumber,
+        [string]$apiBaseUrl = 'https://api.github.com'
     )
 
     # NOTE: Invoke-GHRestMethod does not throw on HTTP errors (e.g. 403/404).
@@ -353,7 +367,7 @@ function Get-DismissalRequestForAlert {
     # See: https://github.com/microsoft/PowerShellForGitHub/wiki/Invoke-GHRestMethod
     # Use -ExtendedResult if you need to inspect the HTTP status code directly.
     try {
-        $url = "/repos/$owner/$repo/dismissal-requests/secret-scanning/$alertNumber"
+        $url = "$($apiBaseUrl.TrimEnd('/'))/repos/$owner/$repo/dismissal-requests/secret-scanning/$alertNumber"
         $response = Invoke-GHRestMethod -Method GET -Uri $url
         if ($response.message) {
             return $null

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ This Action is also helpful in increasing visibility for secrets that are detect
 
 2. A GitHub Access Token with required permissions must be provided. See [token requirements](#token-requirements) below.
 
+## Supported GitHub instances
+
+The action works on github.com, [GitHub Enterprise Cloud with data residency](https://docs.github.com/en/enterprise-cloud@latest/admin/data-residency) (`*.ghe.com`), and GitHub Enterprise Server. The API endpoint is resolved from the runner-provided `GITHUB_API_URL` environment variable, so no additional configuration is required.
+
 ## Functionality
 
 ### Commit Annontations

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/advanced-security/secret-scanning-review-action/badge)](https://scorecard.dev/viewer/?uri=github.com/advanced-security/secret-scanning-review-action)
 ![GitHub License](https://img.shields.io/github/license/advanced-security/secret-scanning-review-action)
 
+[![GitHub.com](https://img.shields.io/badge/Supported%20on-GitHub.com-0969da)](https://github.com)
+[![GHEC with data residency](https://img.shields.io/badge/Supported%20on-GitHub%20Enterprise%20Cloud%20with%20data%20residency-0969da)](https://docs.github.com/en/enterprise-cloud@latest/admin/data-residency)
+[![GHES](https://img.shields.io/badge/Supported%20on-GitHub%20Enterprise%20Server-0969da)](https://docs.github.com/en/enterprise-server@latest)
+
 ## Overview
 
 This Action adds more awareness, and optionally fails a pull request status check, when a secret scanning alert is introduced in commits, pull request title, description, comments, reviews, or review comments as part of a pull request. This makes it harder for peer reviewers to miss the alert and makes it easier to enforce that the alert is resolved before the pull request is merged (when combined with [repository rulesets](https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)).

--- a/action.ps1
+++ b/action.ps1
@@ -143,6 +143,12 @@ $actionRepo = Get-ActionRepo
 $OrganizationName = $actionRepo.Owner
 $RepositoryName = $actionRepo.Repo
 
+# Resolve the GitHub API base URL. GITHUB_API_URL is set by the runner and varies between
+# github.com (https://api.github.com), ghe.com data-residency tenants (https://api.<tenant>.ghe.com),
+# and GHES (https://<hostname>/api/v3). Fall back to public github.com for local/manual runs.
+$ApiBaseUrl = if ([String]::IsNullOrWhiteSpace($env:GITHUB_API_URL)) { 'https://api.github.com' } else { $env:GITHUB_API_URL.TrimEnd('/') }
+Write-ActionDebug "Using GitHub API base URL: $ApiBaseUrl"
+
 #get the pull request number from the GITHUB_REF environment variable
 if ($env:GITHUB_REF -match 'refs/pull/([0-9]+)') {
     $PullRequestNumber = $matches[1]
@@ -159,11 +165,15 @@ Set-GitHubConfiguration -DefaultOwnerName $OrganizationName -DefaultRepositoryNa
     - docs: https://docs.github.com/en/enterprise-cloud@latest/rest/pulls/pulls#get-a-pull-request
     - format: /repos/{owner}/{repo}/pulls/{pull_number}
 #>
+# Call the API directly with an absolute URL rather than Get-GitHubPullRequest, because
+# PowerShellForGitHub's ApiHostName only supports github.com and GHES (it appends /api/v3
+# for any non-github.com host), which breaks against ghe.com data-residency tenants.
+$prUrl = "$ApiBaseUrl/repos/$OrganizationName/$RepositoryName/pulls/$PullRequestNumber"
 try {
-    $pr = Get-GitHubPullRequest -PullRequest $PullRequestNumber
-    # Get the API url for comparison purposes (PowerShellForGitHub module may not return the 'url' field)
-    # Construct it from the org/repo/pr number
-    $pr | Add-Member -MemberType NoteProperty -Name 'url' -Value "https://api.github.com/repos/$OrganizationName/$RepositoryName/pulls/$PullRequestNumber" -Force
+    $pr = Invoke-GHRestMethod -Method GET -Uri $prUrl
+    # PowerShellForGitHub may not include the 'url' field on the returned object; ensure it's set
+    # to the API URL we built so location comparisons against the alert API responses succeed.
+    $pr | Add-Member -MemberType NoteProperty -Name 'url' -Value $prUrl -Force
 }
 catch {
     Set-ActionFailed -Message "Error getting '$OrganizationName/$RepositoryName' PR#$PullRequestNumber info.  Ensure the 'token' input has proper repo permissions. (StatusCode:$($_.Exception.Response.StatusCode.Value__) Message:$($_.Exception.Message)"
@@ -176,7 +186,7 @@ Write-ActionInfo "PR#$PullRequestNumber '$($pr.Title)' has $($pr.commits) commit
 #>
 $prCommitsUrl = [uri]$pr.commits_url
 try {
-    $commits = Invoke-GHRestMethod -Method GET -Uri $prCommitsUrl.AbsolutePath
+    $commits = Invoke-GHRestMethod -Method GET -Uri $prCommitsUrl.AbsoluteUri
 }
 catch {
     Set-ActionFailed -Message "Error getting '$OrganizationName/$RepositoryName' PR#$PullRequestNumber commits.  Ensure the 'token' input has proper repo permissions. (StatusCode:$($_.Exception.Response.StatusCode.Value__) Message:$($_.Exception.Message)"
@@ -201,7 +211,7 @@ Write-ActionInfo "PR#$PullRequestNumber Commit SHA list: $($prCommitShaList -joi
 $perPage = 100
 
 # First call: Get default provider-based secret scanning alerts
-$repoAlertsUrl = "/repos/$OrganizationName/$RepositoryName/secret-scanning/alerts?per_page=$perPage"
+$repoAlertsUrl = "$ApiBaseUrl/repos/$OrganizationName/$RepositoryName/secret-scanning/alerts?per_page=$perPage"
 if ($SkipClosedAlerts) {
     $repoAlertsUrl += "&state=open"
 }
@@ -238,7 +248,7 @@ catch {
 }
 
 # Second call: Get generic secret scanning alerts (non-provider patterns and copilot patterns)
-$genericAlertsUrl = "/repos/$OrganizationName/$RepositoryName/secret-scanning/alerts?per_page=$perPage&secret_type=$GENERIC_SECRET_TYPES"
+$genericAlertsUrl = "$ApiBaseUrl/repos/$OrganizationName/$RepositoryName/secret-scanning/alerts?per_page=$perPage&secret_type=$GENERIC_SECRET_TYPES"
 if ($SkipClosedAlerts) {
     $genericAlertsUrl += "&state=open"
 }
@@ -287,7 +297,7 @@ foreach ($alert in $alerts) {
     #>
     $repoAlertLocationUrl = [uri]"$($alert.locations_url)?per_page=$perPage"
     try {
-        $locationsResult = Invoke-GHRestMethod -Method GET -Uri "$($repoAlertLocationUrl.AbsolutePath)$($repoAlertLocationUrl.Query)" -ExtendedResult $true
+        $locationsResult = Invoke-GHRestMethod -Method GET -Uri $repoAlertLocationUrl.AbsoluteUri -ExtendedResult $true
         $locations = $locationsResult.result
         # Get the next page of secret scanning alert locations if there is one
         while ($locationsResult.nextLink) {
@@ -327,7 +337,7 @@ foreach ($alert in $alerts) {
                 }
             }
             'pull_request_comment' {
-                $prComments = Get-PullRequestComment -owner $OrganizationName -repo $RepositoryName -pullNumber $PullRequestNumber
+                $prComments = Get-PullRequestComment -owner $OrganizationName -repo $RepositoryName -pullNumber $PullRequestNumber -apiBaseUrl $ApiBaseUrl
                 # Extract comment ID from the URL (last segment of the path)
                 $commentId = Get-IdFromUrl -url $location.details.pull_request_comment_url
                 foreach ($comment in $prComments) {
@@ -399,7 +409,7 @@ foreach ($alert in $alertsInitiatedFromPr) {
     $numSecretsAlertsDetected++
 
     # Fetch dismissal request for this alert (may return null if feature is not enabled or no request exists)
-    $dismissalRequest = Get-DismissalRequestForAlert -owner $OrganizationName -repo $RepositoryName -alertNumber $alert.number
+    $dismissalRequest = Get-DismissalRequestForAlert -owner $OrganizationName -repo $RepositoryName -alertNumber $alert.number -apiBaseUrl $ApiBaseUrl
     $dismissalState = Get-AlertDismissalState -alert $alert -dismissalRequest $dismissalRequest
     $dismissalStatus = $dismissalState.dismissalStatus
     $alert | Add-Member -MemberType NoteProperty -Name 'dismissal_request_status' -Value $dismissalStatus -Force
@@ -463,7 +473,7 @@ if (!$DisablePRComment -and $alertsInitiatedFromPr.Count -gt 0) {
     - docs: https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#get-an-issue-comment
     - format: /repos/{owner}/{repo}/issues/{pull_number}/comments
     #>
-    $commentUrl = "/repos/$OrganizationName/$RepositoryName/issues/$PullRequestNumber/comments?per_page=100"
+    $commentUrl = "$ApiBaseUrl/repos/$OrganizationName/$RepositoryName/issues/$PullRequestNumber/comments?per_page=100"
     try {
         $comments = Invoke-GHRestMethod -Method GET -Uri $commentUrl
     }

--- a/action.py
+++ b/action.py
@@ -14,6 +14,12 @@ from datetime import datetime, timezone
 # Includes non-provider patterns and copilot patterns
 GENERIC_SECRET_TYPES = "password,ec_private_key,generic_private_key,http_basic_authentication_header,http_bearer_authentication_header,mongodb_connection_string,mysql_connection_url,openssh_private_key,pgp_private_key,postgres_connection_string,rsa_private_key"
 
+def get_api_base_url():
+    # GITHUB_API_URL is provided by the runner and points to the correct API host for the
+    # current GitHub instance (github.com, ghe.com data-residency tenants, or GHES).
+    # Fall back to public github.com for local/manual runs outside a workflow.
+    return os.environ.get('GITHUB_API_URL', 'https://api.github.com').rstrip('/')
+
 def get_commits_for_pr(github_token, repo_owner, repo_name, pull_request_number, http_proxy_url, https_proxy_url, verify_ssl):
     # API documentation: https://docs.github.com/en/enterprise-cloud@latest/rest/pulls/pulls?apiVersion=2022-11-28#list-commits-on-a-pull-request
     all_commits = []
@@ -21,7 +27,7 @@ def get_commits_for_pr(github_token, repo_owner, repo_name, pull_request_number,
     page = 1
     while True:
         try:
-            url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pull_request_number}/commits?per_page={per_page}&page={page}"
+            url = f"{get_api_base_url()}/repos/{repo_owner}/{repo_name}/pulls/{pull_request_number}/commits?per_page={per_page}&page={page}"
             headers = {
                 "Authorization": f"Bearer {github_token}",
                 "Accept": "application/vnd.github+json",
@@ -56,7 +62,7 @@ def get_secret_scanning_alerts_for_repo(github_token, repo_owner, repo_name, htt
     page = 1
     while True:
         try:
-            url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/secret-scanning/alerts?per_page={per_page}&page={page}"
+            url = f"{get_api_base_url()}/repos/{repo_owner}/{repo_name}/secret-scanning/alerts?per_page={per_page}&page={page}"
             if skip_closed_alerts:
                 url += "&state=open"
             if secret_type is not None:
@@ -101,7 +107,7 @@ def get_locations_for_alert(github_token, repo_owner, repo_name, alert_number, h
     page = 1
     while True:
         try:
-            url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/secret-scanning/alerts/{alert_number}/locations?per_page={per_page}&page={page}"
+            url = f"{get_api_base_url()}/repos/{repo_owner}/{repo_name}/secret-scanning/alerts/{alert_number}/locations?per_page={per_page}&page={page}"
             headers = {
                 "Authorization": f"Bearer {github_token}",
                 "Accept": "application/vnd.github+json",
@@ -138,7 +144,7 @@ def get_locations_for_alert(github_token, repo_owner, repo_name, alert_number, h
 def get_dismissal_request_for_alert(github_token, repo_owner, repo_name, alert_number, http_proxy_url, https_proxy_url, verify_ssl):
     # API documentation: https://docs.github.com/en/enterprise-cloud@latest/rest/secret-scanning/alert-dismissal-requests#get-an-alert-dismissal-request-for-secret-scanning
     try:
-        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/dismissal-requests/secret-scanning/{alert_number}"
+        url = f"{get_api_base_url()}/repos/{repo_owner}/{repo_name}/dismissal-requests/secret-scanning/{alert_number}"
         headers = {
             "Authorization": f"Bearer {github_token}",
             "Accept": "application/vnd.github+json",
@@ -154,7 +160,7 @@ def get_dismissal_request_for_alert(github_token, repo_owner, repo_name, alert_n
 def get_pull_request(github_token, repo_owner, repo_name, pull_request_number, http_proxy_url, https_proxy_url, verify_ssl):
     # API documentation: https://docs.github.com/en/enterprise-cloud@latest/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request
     try:
-        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pull_request_number}"
+        url = f"{get_api_base_url()}/repos/{repo_owner}/{repo_name}/pulls/{pull_request_number}"
         headers = {
             "Authorization": f"Bearer {github_token}",
             "Accept": "application/vnd.github+json",
@@ -182,7 +188,7 @@ def update_pull_request_comment(github_token, repo_owner, repo_name, pull_reques
     comments = []
     per_page = 100
     page = 1
-    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/{pull_request_number}/comments?per_page={per_page}&page={page}"
+    url = f"{get_api_base_url()}/repos/{repo_owner}/{repo_name}/issues/{pull_request_number}/comments?per_page={per_page}&page={page}"
     headers = {
         'Authorization': f'Bearer {github_token}',
         'Accept': 'application/vnd.github+json'
@@ -194,7 +200,7 @@ def update_pull_request_comment(github_token, repo_owner, repo_name, pull_reques
             response.raise_for_status()
             page_comments = response.json()
             comments.extend(page_comments)
-            
+
             # Check if there are more pages
             if len(page_comments) < 100:
                 break
@@ -233,7 +239,7 @@ def get_pull_request_comments(github_token, repo_owner, repo_name, pull_request_
     comments = []
     per_page = 100
     page = 1
-    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/{pull_request_number}/comments?per_page={per_page}&page={page}"
+    url = f"{get_api_base_url()}/repos/{repo_owner}/{repo_name}/issues/{pull_request_number}/comments?per_page={per_page}&page={page}"
     headers = {
         'Authorization': f'Bearer {github_token}',
         'Accept': 'application/vnd.github+json'
@@ -245,7 +251,7 @@ def get_pull_request_comments(github_token, repo_owner, repo_name, pull_request_
             response.raise_for_status()
             page_comments = response.json()
             comments.extend(page_comments)
-            
+
             # Check if there are more pages
             if len(page_comments) < 100:
                 break

--- a/tests/Action_tests.ps1
+++ b/tests/Action_tests.ps1
@@ -227,6 +227,28 @@ Describe 'Get-PullRequestComment' {
         $result = Get-PullRequestComment -owner 'owner' -repo 'repo' -pullNumber 42
         $result.Count | Should -Be 2
     }
+
+    It 'Defaults to api.github.com when no apiBaseUrl is provided' {
+        $mockComments = @( @{ id = 1; body = 'Comment 1' } )
+        Mock Invoke-GHRestMethod { return $mockComments } -ModuleName ActionHelpers
+
+        Get-PullRequestComment -owner 'owner' -repo 'repo' -pullNumber 42
+
+        Should -Invoke Invoke-GHRestMethod -Times 1 -ModuleName ActionHelpers -ParameterFilter {
+            $Uri -like 'https://api.github.com/repos/owner/repo/issues/42/comments*'
+        }
+    }
+
+    It 'Uses the provided apiBaseUrl (ghe.com support)' {
+        $mockComments = @( @{ id = 1; body = 'Comment 1' } )
+        Mock Invoke-GHRestMethod { return $mockComments } -ModuleName ActionHelpers
+
+        Get-PullRequestComment -owner 'owner' -repo 'repo' -pullNumber 42 -apiBaseUrl 'https://api.tenant.ghe.com'
+
+        Should -Invoke Invoke-GHRestMethod -Times 1 -ModuleName ActionHelpers -ParameterFilter {
+            $Uri -like 'https://api.tenant.ghe.com/repos/owner/repo/issues/42/comments*'
+        }
+    }
 }
 
 Describe 'Write-AlertAnnotation' {

--- a/tests/Action_tests.ps1
+++ b/tests/Action_tests.ps1
@@ -309,7 +309,17 @@ Describe 'Get-DismissalRequestForAlert' {
         Get-DismissalRequestForAlert -owner 'myorg' -repo 'myrepo' -alertNumber 99
 
         Should -Invoke Invoke-GHRestMethod -Times 1 -ModuleName ActionHelpers -ParameterFilter {
-            $Uri -eq '/repos/myorg/myrepo/dismissal-requests/secret-scanning/99' -and $Method -eq 'GET'
+            $Uri -eq 'https://api.github.com/repos/myorg/myrepo/dismissal-requests/secret-scanning/99' -and $Method -eq 'GET'
+        }
+    }
+
+    It 'Uses the provided apiBaseUrl (ghe.com support)' {
+        Mock Invoke-GHRestMethod { return @{ status = 'approved' } } -ModuleName ActionHelpers
+
+        Get-DismissalRequestForAlert -owner 'myorg' -repo 'myrepo' -alertNumber 99 -apiBaseUrl 'https://api.tenant.ghe.com'
+
+        Should -Invoke Invoke-GHRestMethod -Times 1 -ModuleName ActionHelpers -ParameterFilter {
+            $Uri -eq 'https://api.tenant.ghe.com/repos/myorg/myrepo/dismissal-requests/secret-scanning/99' -and $Method -eq 'GET'
         }
     }
 


### PR DESCRIPTION
## Summary

- Resolve the GitHub REST API base URL from the runner-provided `GITHUB_API_URL` environment variable so the action works against github.com, [ghe.com data residency tenants](https://docs.github.com/en/enterprise-cloud@latest/admin/data-residency), and GHES.
- Replace hardcoded `https://api.github.com` URLs in both the PowerShell (`action.ps1` / `ActionHelpers.psm1`) and Python (`action.py`) runtimes.
- Drop the `Get-GitHubPullRequest` call and build absolute URLs for `Invoke-GHRestMethod`. PowerShellForGitHub's `ApiHostName` only supports github.com (mapped to `api.github.com`) and GHES (appends `/api/v3` to anything else), so it cannot reach `api.<tenant>.ghe.com` correctly. Absolute URIs are passed through unchanged by `Invoke-GHRestMethod`, which sidesteps the limitation without forcing a module migration.

## Why

GitHub Enterprise Cloud with data residency hosts the API at `https://api.<tenant>.ghe.com`. Hardcoding `https://api.github.com` made the action unusable on those tenants. `GITHUB_API_URL` is already set by the runner to the correct host on all GitHub instances, so using it removes the need for any user-facing configuration.

## Test plan

- [ ] Pester tests pass (`tests/Action_tests.ps1`) — added a new assertion covering the `-apiBaseUrl` parameter on `Get-DismissalRequestForAlert`.
- [ ] Run the action on a github.com repo (regression check).
- [ ] Run the action on a ghe.com tenant repo and confirm alerts/locations/dismissals/PR comments work end-to-end.
- [ ] Run with the Python runtime (`runtime: python`) on github.com and on ghe.com.