### PR TITLE
feat: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Explicit version (e.g., 2.3.0). Leave empty to use bump."
+        required: false
+        type: string
+        default: ''
+      bump:
+        description: "Auto-bump from latest release (patch/minor/major). Ignored if version is set."
+        required: false
+        type: choice
+        options:
+          - ''
+          - patch
+          - minor
+          - major
+      prerelease:
+        description: "Create as a pre-release"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  release:
+    uses: advanced-security/reusable-workflows/.github/workflows/release.yml@7953983740745d7bd04ae675dd795e9445b690ac # v0.3.1
+    with:
+      version: ${{ inputs.version }}
+      bump: ${{ inputs.bump }}
+      prerelease: ${{ inputs.prerelease }}
+    permissions:
+      contents: write


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` release workflow that calls the reusable release workflow from `advanced-security/reusable-workflows@v0.3.1`.

### Inputs

| Input | Type | Description |
|-------|------|-------------|
| `version` | string | Explicit version (e.g., `2.3.0`). Leave empty to use bump. |
| `bump` | choice | Auto-bump from latest release (`patch`/`minor`/`major`). Ignored if version is set. |
| `prerelease` | boolean | Create as a pre-release (default: false) |

### Usage

To create `v2.2.7` as a prerelease:
1. Go to Actions → Release → Run workflow
2. Select `bump: patch` + `prerelease: true`

To promote it later:
1. Run again with `version: 2.2.7` + `prerelease: false`