### PR TITLE
fix: add pull-requests:write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,4 @@ jobs:
       prerelease: ${{ inputs.prerelease }}
     permissions:
       contents: write
+      pull-requests: write


### PR DESCRIPTION
The reusable release workflow's update-readme-sha job needs pull-requests: write to open PRs.