### PR TITLE
feat: enable update-readme-sha in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       version: ${{ inputs.version }}
       bump: ${{ inputs.bump }}
       prerelease: ${{ inputs.prerelease }}
+      update-readme-sha: true
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Adds update-readme-sha: true to the release workflow call. When a non-prerelease is published, this will automatically open a PR to update SHA-pinned action references in README.md.